### PR TITLE
Update Python Basics.ipynb

### DIFF
--- a/Day 01/Python Basics.ipynb
+++ b/Day 01/Python Basics.ipynb
@@ -108,7 +108,7 @@
         "print(type(y), \": \", y)\n",
         "print(type(z), \": \", z)\n",
         "print(type(w), \": \", w)\n",
-        "print(type(u), \": \", v)\n",
+        "print(type(v), \": \", v)\n",
         "print(type(u), \": \", u)\n"
       ],
       "execution_count": 2,
@@ -145,7 +145,7 @@
         "print(4*2.0) # multiplication of an int and a float (the result is a float)\n",
         "print(5/2) # floating point division\n",
         "print(5.6//2) # integer division\n",
-        "print(type(5.6//2)) # the result is an int\n",
+        "print(type(5.6//2)) # the result is an float\n",
         "print(5 % 2) # modulo operator (division remainder)\n",
         "print(2**4) # exponentiation"
       ],
@@ -782,8 +782,8 @@
         "id": "IVtkIFiim9GQ"
       },
       "source": [
-        "print(squared_diff(5,1))\n",
-        "print(squared_diff(3,6))"
+        "print(square(5))\n",
+        "print(square(3))"
       ],
       "execution_count": null,
       "outputs": []
@@ -884,7 +884,7 @@
         "id": "sy8fO1drnW8g"
       },
       "source": [
-        "def f4(arg1, arg2, *positional_args,, **keyword_args):\n",
+        "def f4(arg1, arg2, *positional_args, c, **keyword_args):\n",
         "    print(arg1)\n",
         "    print(arg2)\n",
         "    print(positional_args)\n",
@@ -903,7 +903,7 @@
         "id": "B8qSedzJnjOP"
       },
       "source": [
-        "We can also pass tuples and dictionaries ad positional arguments and keyword arguments directly"
+        "We can also pass tuples and dictionaries and positional arguments and keyword arguments directly"
       ]
     },
     {


### PR DESCRIPTION
changed: 
print(type(u), ": ", v)  -----------> print(type(v), \": \", v)
print(type(5.6//2)) # the result is an int -----------> "print(type(5.6//2)) # the result is an float\n"

In the function section you defined a "square" function and called a "squared_diff" function which is not defined so I propose these changes:
print(squared_diff(5,1)) --------> "print(square(5))\n"
print(squared_diff(3,6)) --------> "print(square(3))"

also this piece of code gives a syntax error: (just adding a "c" variable would do the trick)

def f4(arg1, arg2, *positional_args,, **keyword_args): ---------> def f4(arg1, arg2, *positional_args, c , **keyword_args):
    print(arg1)
    print(arg2)
    print(positional_args)
    print(c)
    print(keyword_args)

f4(1,2,3,4,a=5,b=6,c = 7)

and after running the next cell it would not give us the expected output(*x would be assigned to arg1,arg2,*positional_args and apparently c while y would be assigned to **keyword_args) It actually got me confused cause "c" would be assigned to ('c':'d') which is within the dictionary and I don't think that's right so I would suggest to rename the variable (c) within the function to avoid the conflict (but that up to you to handle I'm just pointing out that conflict):
x = (1,2,3,4)
y = {'a':'b', 'c':'d'}
f4(*x,**y)

## I would love to her your feedback on my proposes,
best wishes